### PR TITLE
(GH-958) Add Spec tests for Ruby 2.5, 2.7 on Github Actions

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,0 +1,38 @@
+name: "Static & Spec Tests"
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  StaticAndSpecTests:
+    name: "Static & Spec Tests (Ruby ${{ matrix.ruby_version }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.5', '2.7']
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v2
+
+    - name: "Activate Ruby ${{ matrix.ruby_version }}"
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby_version }}
+        bundler-cache: true
+        without: "development"
+
+    - name: Rubocop
+      run: bundle exec rake rubocop
+
+    - name: 'Spec:Coverage'
+      run: bundle exec rake spec:coverage
+
+    - name: 'License Finder'
+      run: bundle exec rake license_finder
+
+    - name: 'Test PDK as Library'
+      run: bundle exec rake test_pdk_as_library
+
+    - name: 'Spec'
+      run: bundle exec rake spec


### PR DESCRIPTION
This PR adds the following test / coverage suites to a
Github Actions workflow on both Ruby 2.5 and 2.7:

- `rubocop`
- `spec:coverage`
- `license_finder`
- `test_pdk_as_library`
- `spec`